### PR TITLE
Besserer Umgang mit unsichtbaren Fahrten

### DIFF
--- a/src/de/stsFanGruppe/templatebuilder/editor/bildfahrplan/BildfahrplanGUIController.java
+++ b/src/de/stsFanGruppe/templatebuilder/editor/bildfahrplan/BildfahrplanGUIController.java
@@ -128,7 +128,7 @@ public class BildfahrplanGUIController extends EditorGUIController
 	
 	public void jumpToZug(double ab, double an)
 	{
-		int top = (int) ph.getZeitPos(ab);
+		int top = (int) ph.getZeitPos(Math.min(an, ab));
 		int viewportHeight = (int) gui.getVisibleRect().getHeight();
 		
 		/* Springe zum Start der Fahrt

--- a/src/de/stsFanGruppe/templatebuilder/editor/bildfahrplan/BildfahrplanGUIController.java
+++ b/src/de/stsFanGruppe/templatebuilder/editor/bildfahrplan/BildfahrplanGUIController.java
@@ -435,7 +435,11 @@ public class BildfahrplanGUIController extends EditorGUIController
 			boolean zeigeZeiten = bildfahrplanConfig.getZeigeZeiten();
 			int zeigeRichtung = bildfahrplanConfig.getZeigeRichtung();
 			
-			Set<Fahrt> fahrten = editorDaten.getFahrten();
+			// Ignoriere Fahrten mit weniger als 2 Fahrplanhalten, weil die eh nicht gezeichnet werden
+			Set<Fahrt> fahrten = editorDaten.getFahrten()
+					.stream()
+					.filter(fahrt -> fahrt.getFahrplanhalte().size() > 1)
+					.collect(Collectors.toSet());
 			
 			synchronized(fahrten)
 			{

--- a/src/de/stsFanGruppe/templatebuilder/gui/TemplateBuilderGUIController.java
+++ b/src/de/stsFanGruppe/templatebuilder/gui/TemplateBuilderGUIController.java
@@ -8,6 +8,8 @@ import java.util.HashSet;
 import java.util.Hashtable;
 import java.util.Set;
 import java.util.StringJoiner;
+import java.util.stream.Collectors;
+
 import de.stsFanGruppe.templatebuilder.config.BildfahrplanConfig;
 import de.stsFanGruppe.templatebuilder.config.BildfahrplanSettingsGUI;
 import de.stsFanGruppe.templatebuilder.config.BildfahrplanSettingsGUIController;
@@ -460,7 +462,11 @@ public class TemplateBuilderGUIController extends GUIController
 		if(daten == null) {
 			return new HashSet<>();
 		}
-		return daten.getTemplates();
+		
+		return daten.getTemplates()
+				.stream()
+				.filter(template -> template.hasSichtbareFahrten())
+				.collect(Collectors.toSet());
 	}
 	
 	private EditorDaten getEditorDaten() {

--- a/src/de/stsFanGruppe/templatebuilder/zug/Fahrt.java
+++ b/src/de/stsFanGruppe/templatebuilder/zug/Fahrt.java
@@ -181,6 +181,11 @@ public class Fahrt implements Comparable<Fahrt>, XMLExportable
 		return false;
 	}
 	
+	public boolean isSichtbar()
+	{
+		return fahrplanhalte.size() > 1;
+	}
+	
 	public String toString()
 	{
 		StringBuilder stringBuilder = new StringBuilder("Fahrt " + getName() + " { Linie: " + getLinie());

--- a/src/de/stsFanGruppe/templatebuilder/zug/Template.java
+++ b/src/de/stsFanGruppe/templatebuilder/zug/Template.java
@@ -102,6 +102,11 @@ public class Template implements Comparable<Template>, XMLExportable
 		return !fahrten.isEmpty();
 	}
 	
+	public boolean hasSichtbareFahrten()
+	{
+		return fahrten.stream().anyMatch(fahrt -> fahrt.isSichtbar());
+	}
+	
 	public Set<Fahrt> getFahrten()
 	{
 		return fahrten;

--- a/src/de/stsFanGruppe/templatebuilder/zug/Template.java
+++ b/src/de/stsFanGruppe/templatebuilder/zug/Template.java
@@ -138,14 +138,12 @@ public class Template implements Comparable<Template>, XMLExportable
 		
 		for(Fahrt fahrt : fahrten)
 		{
-			log.debug("Fahrt {}", fahrt);
-			if(fahrt.getMaxZeit() < minZeit)
+			if(fahrt.getMinZeit() < minZeit)
 			{
 				continue;
 			}
 			if(first == null || first.compareTo(fahrt) > 0)
 			{
-				log.debug("... ist früher");
 				first = fahrt;
 			}
 		}


### PR DESCRIPTION
* Fahrten mit weniger als 2 Fahrplanhalten werden im Bildfahrplan und in der Schachtelung ignoriert, da sie eh nicht sichtbar sind
* Verbesserung beim Springen zu sehr frühen Zügen, deren vorletzter Fahrplanhalt nicht sichtbar ist